### PR TITLE
add explicity dep on box2d-py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools import setup
 
 setup (name = 'gym_copter',
     version = '0.1',
-    install_requires = ['gym', 'numpy'],
+    install_requires = ['gym', 'numpy', 'box2d-py'],
     description = 'Gym environment for multicopters',
     packages = ['gym_copter', 'gym_copter.envs', 'gym_copter.dynamics', 'gym_copter.rendering'],
     author='Simon D. Levy',


### PR DESCRIPTION
Hey @simondlevy! Really like your package here! (esp the rendering)
I tried to run the 2d quadcopter but I found out I had to install `box2d-py` for the rendering to show up, (didn't come with `gym` as I thought it would have)
Adding it as a req fixed the issue for me.

Another option is to add `gym[box2d]` as a req but I think it is sufficient to specify just `box2d-py`. Let me know what you think!

ref: https://github.com/openai/gym/blob/master/setup.py#L11

Again thanks for maintaining this package!